### PR TITLE
shared/web/scripts: Uncomment exit on error

### DIFF
--- a/shared/web/scripts/generateIdentity.sh
+++ b/shared/web/scripts/generateIdentity.sh
@@ -74,8 +74,8 @@ count=$(/bin/ls $identityDirPath | wc -l)
 if [[ $count -lt 4 ]]
 then
     logMessage "ERROR: All Identity files not generated on run" 
-    #rm ${identityPidFile}
-    #exit 4
+    rm ${identityPidFile}
+    exit 4
 fi
 
 logMessage "Authorizing identity using identity key string (IdentityPidRef:${BG_PID}) "


### PR DESCRIPTION
Uncomment forgotten commented instruction that exits if the identity
generation process doesn't produce the expected number of files.

__NOTE__ I'm not sure if those lines were commented and were merged unintentionally or intentionally. In this PR I assumed that they were merged __unintentionally__ if that isn't the case I will cancel the PR and I will open a new one removing those commented lines.